### PR TITLE
Fix compatibility with ES 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 
 This [REST Layer](https://github.com/rs/rest-layer) resource storage backend stores data in an ElasticSearch cluster using [olivere/elastic](http://gopkg.in/olivere/elastic.v3).
 
+ElasticSearch v5+ is required.
+
 ## Usage
 
 ```go
 import "github.com/rs/rest-layer-es"
 ```
 
-Create an [elastic]("http://gopkg.in/olivere/elastic.v3") client:
+Create an [elastic]("http://gopkg.in/olivere/elastic.v5") client:
 
 ```go
 client, err := elastic.NewClient()

--- a/elastic_test.go
+++ b/elastic_test.go
@@ -231,38 +231,95 @@ func TestFind(t *testing.T) {
 		}
 	}
 
-	// FIXME $in and $nin are broken with "Fielddata is disabled on text fields by default." error.
-	// q, err = query.New("", `{name:{$in:["c","d"]}}`, "name", query.Page(1, 100, 0))
-	// if assert.NoError(t, err) {
-	// 	l, err := h.Find(ctx, q)
-	// 	if assert.NoError(t, err) {
-	// 		assert.Equal(t, 2, l.Total)
-	// 		if assert.Len(t, l.Items, 2) {
-	// 			item := l.Items[0]
-	// 			assert.Equal(t, "3", item.ID)
-	// 			assert.Equal(t, map[string]interface{}{"id": "3", "name": "c", "age": float64(3)}, item.Payload)
-	// 			item = l.Items[1]
-	// 			assert.Equal(t, "4", item.ID)
-	// 			assert.Equal(t, map[string]interface{}{"id": "4", "name": "d", "age": float64(4)}, item.Payload)
-	// 		}
-	// 	}
-	// }
+	q, err = query.New("", `{name:{$in:["c","d"]}}`, "name", query.Page(1, 100, 0))
+	if assert.NoError(t, err) {
+		l, err := h.Find(ctx, q)
+		if assert.NoError(t, err) {
+			assert.Equal(t, 2, l.Total)
+			if assert.Len(t, l.Items, 2) {
+				item := l.Items[0]
+				assert.Equal(t, "3", item.ID)
+				assert.Equal(t, map[string]interface{}{"id": "3", "name": "c", "age": float64(3)}, item.Payload)
+				item = l.Items[1]
+				assert.Equal(t, "4", item.ID)
+				assert.Equal(t, map[string]interface{}{"id": "4", "name": "d", "age": float64(4)}, item.Payload)
+			}
+		}
+	}
 
-	// q, err = query.New("", `{name:{$nin:["c","d"]}}`, "name", query.Page(1, 100, 0))
-	// if assert.NoError(t, err) {
-	// 	l, err := h.Find(ctx, q)
-	// 	if assert.NoError(t, err) {
-	// 		assert.Equal(t, 2, l.Total)
-	// 		if assert.Len(t, l.Items, 2) {
-	// 			item := l.Items[0]
-	// 			assert.Equal(t, "3", item.ID)
-	// 			assert.Equal(t, map[string]interface{}{"id": "3", "name": "c", "age": float64(3)}, item.Payload)
-	// 			item = l.Items[1]
-	// 			assert.Equal(t, "4", item.ID)
-	// 			assert.Equal(t, map[string]interface{}{"id": "4", "name": "d", "age": float64(4)}, item.Payload)
-	// 		}
-	// 	}
-	// }
+	q, err = query.New("", `{name:{$nin:["c","d"]}}`, "name", query.Page(1, 100, 0))
+	if assert.NoError(t, err) {
+		l, err := h.Find(ctx, q)
+		if assert.NoError(t, err) {
+			assert.Equal(t, 2, l.Total)
+			if assert.Len(t, l.Items, 2) {
+				item := l.Items[0]
+				assert.Equal(t, "1", item.ID)
+				assert.Equal(t, map[string]interface{}{"id": "1", "name": "a", "age": float64(1)}, item.Payload)
+				item = l.Items[1]
+				assert.Equal(t, "2", item.ID)
+				assert.Equal(t, map[string]interface{}{"id": "2", "name": "b", "age": float64(2)}, item.Payload)
+			}
+		}
+	}
+
+	q, err = query.New("", `{age:{$lt:2}}`, "name", query.Page(1, 100, 0))
+	if assert.NoError(t, err) {
+		l, err := h.Find(ctx, q)
+		if assert.NoError(t, err) {
+			assert.Equal(t, 1, l.Total)
+			if assert.Len(t, l.Items, 1) {
+				item := l.Items[0]
+				assert.Equal(t, "1", item.ID)
+				assert.Equal(t, map[string]interface{}{"id": "1", "name": "a", "age": float64(1)}, item.Payload)
+			}
+		}
+	}
+
+	q, err = query.New("", `{age:{$lte:2}}`, "name", query.Page(1, 100, 0))
+	if assert.NoError(t, err) {
+		l, err := h.Find(ctx, q)
+		if assert.NoError(t, err) {
+			assert.Equal(t, 2, l.Total)
+			if assert.Len(t, l.Items, 2) {
+				item := l.Items[0]
+				assert.Equal(t, "1", item.ID)
+				assert.Equal(t, map[string]interface{}{"id": "1", "name": "a", "age": float64(1)}, item.Payload)
+				item = l.Items[1]
+				assert.Equal(t, "2", item.ID)
+				assert.Equal(t, map[string]interface{}{"id": "2", "name": "b", "age": float64(2)}, item.Payload)
+			}
+		}
+	}
+
+	q, err = query.New("", `{age:{$gt:3}}`, "name", query.Page(1, 100, 0))
+	if assert.NoError(t, err) {
+		l, err := h.Find(ctx, q)
+		if assert.NoError(t, err) {
+			assert.Equal(t, 1, l.Total)
+			if assert.Len(t, l.Items, 1) {
+				item := l.Items[0]
+				assert.Equal(t, "4", item.ID)
+				assert.Equal(t, map[string]interface{}{"id": "4", "name": "d", "age": float64(4)}, item.Payload)
+			}
+		}
+	}
+
+	q, err = query.New("", `{age:{$gte:3}}`, "name", query.Page(1, 100, 0))
+	if assert.NoError(t, err) {
+		l, err := h.Find(ctx, q)
+		if assert.NoError(t, err) {
+			assert.Equal(t, 2, l.Total)
+			if assert.Len(t, l.Items, 2) {
+				item := l.Items[0]
+				assert.Equal(t, "3", item.ID)
+				assert.Equal(t, map[string]interface{}{"id": "3", "name": "c", "age": float64(3)}, item.Payload)
+				item = l.Items[1]
+				assert.Equal(t, "4", item.ID)
+				assert.Equal(t, map[string]interface{}{"id": "4", "name": "d", "age": float64(4)}, item.Payload)
+			}
+		}
+	}
 
 	q, err = query.New("", `{id:"3"}`, "", query.Page(1, 1, 0))
 	if assert.NoError(t, err) {

--- a/query_test.go
+++ b/query_test.go
@@ -34,9 +34,9 @@ func TestGetQuery(t *testing.T) {
 		{`{id:"foo"}`, nil,
 			elastic.NewTermQuery("_id", "foo")},
 		{`{f:"foo"}`, nil,
-			elastic.NewTermQuery("f", "foo")},
+			elastic.NewTermQuery("f.keyword", "foo")},
 		{`{f:{$ne:"foo"}}`, nil,
-			elastic.NewBoolQuery().MustNot(elastic.NewTermQuery("f", "foo"))},
+			elastic.NewBoolQuery().MustNot(elastic.NewTermQuery("f.keyword", "foo"))},
 		{`{f:{$gt:1}}`, nil,
 			elastic.NewRangeQuery("f").From(float64(1)).IncludeLower(false).IncludeUpper(true)},
 		{`{f:{$gte:1}}`, nil,
@@ -46,15 +46,15 @@ func TestGetQuery(t *testing.T) {
 		{`{f:{$lte:1}}`, nil,
 			elastic.NewRangeQuery("f").To(float64(1)).IncludeLower(true).IncludeUpper(true)},
 		{`{f:{$in:["foo","bar"]}}`, nil,
-			elastic.NewTermsQuery("f", "foo", "bar")},
+			elastic.NewTermsQuery("f.keyword", "foo", "bar")},
 		{`{f:{$nin:["foo","bar"]}}`, nil,
-			elastic.NewBoolQuery().MustNot(elastic.NewTermsQuery("f", "foo", "bar"))},
+			elastic.NewBoolQuery().MustNot(elastic.NewTermsQuery("f.keyword", "foo", "bar"))},
 		{`{f:{$regex:"fo[o]{1}.+is.+some"}}`, resource.ErrNotImplemented,
 			nil},
 		{`{$and:[{f:"foo"},{f:"bar"}]}`, nil,
-			elastic.NewBoolQuery().Must(elastic.NewTermQuery("f", "foo"), elastic.NewTermQuery("f", "bar"))},
+			elastic.NewBoolQuery().Must(elastic.NewTermQuery("f.keyword", "foo"), elastic.NewTermQuery("f.keyword", "bar"))},
 		{`{$or:[{f:"foo"},{f:"bar"}]}`, nil,
-			elastic.NewBoolQuery().Should(elastic.NewTermQuery("f", "foo"), elastic.NewTermQuery("f", "bar"))},
+			elastic.NewBoolQuery().Should(elastic.NewTermQuery("f.keyword", "foo"), elastic.NewTermQuery("f.keyword", "bar"))},
 	}
 	for i := range cases {
 		tc := cases[i]
@@ -89,14 +89,14 @@ func TestGetSort(t *testing.T) {
 	s = getSort(&query.Query{Sort: query.Sort{}})
 	assert.Equal(t, []elastic.Sorter(nil), s)
 	s = getSort(&query.Query{Sort: query.Sort{{Name: "id"}}})
-	assert.Equal(t, []elastic.Sorter{elastic.NewFieldSort(getField("_id")).Asc()}, s)
+	assert.Equal(t, []elastic.Sorter{elastic.NewFieldSort(getField("id", true)).Asc()}, s)
 	s = getSort(&query.Query{Sort: query.Sort{{Name: "f"}}})
-	assert.Equal(t, []elastic.Sorter{elastic.NewFieldSort(getField("f")).Asc()}, s)
+	assert.Equal(t, []elastic.Sorter{elastic.NewFieldSort(getField("f", true)).Asc()}, s)
 	s = getSort(&query.Query{Sort: query.Sort{{Name: "f", Reversed: true}}})
-	assert.Equal(t, []elastic.Sorter{elastic.NewFieldSort(getField("f")).Desc()}, s)
+	assert.Equal(t, []elastic.Sorter{elastic.NewFieldSort(getField("f", true)).Desc()}, s)
 	s = getSort(&query.Query{Sort: query.Sort{{Name: "f"}, {Name: "f", Reversed: true}}})
 	assert.Equal(t, []elastic.Sorter{
-		elastic.NewFieldSort(getField("f")).Asc(),
-		elastic.NewFieldSort(getField("f")).Desc(),
+		elastic.NewFieldSort(getField("f", true)).Asc(),
+		elastic.NewFieldSort(getField("f", true)).Desc(),
 	}, s)
 }


### PR DESCRIPTION
ES version 5 comes with a new default regarding mapping of string
fields. The field itself is text and a subfield (keyword) is not
analysed. To perform exact match operations, the keyword subquery needs
to be used.

By doing this, we force the use of ES 5+ and prevent customization of
the mapping, for instance, to remove the intermediary analized field. A
better fix might be to read the mappings and detect keyword subfield
when present.

See https://www.elastic.co/blog/strings-are-dead-long-live-strings

Thx @agirbal for the tip.