### PR TITLE
Due to change in rs/rest-layer #204, receive `Expression` query param…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: go
 go:
-  - 1.7
+  - 1.9
   - tip
 matrix:
   allow_failures:

--- a/query.go
+++ b/query.go
@@ -58,9 +58,9 @@ func translatePredicate(q query.Predicate) ([]elastic.Query, error) {
 	qs := []elastic.Query{}
 	for _, exp := range q {
 		switch t := exp.(type) {
-		case query.And:
+		case *query.And:
 			and := elastic.NewBoolQuery()
-			for _, subExp := range t {
+			for _, subExp := range *t {
 				sq, err := translatePredicate(query.Predicate{subExp})
 				if err != nil {
 					return nil, err
@@ -68,9 +68,9 @@ func translatePredicate(q query.Predicate) ([]elastic.Query, error) {
 				and.Must(sq...)
 			}
 			qs = append(qs, and)
-		case query.Or:
+		case *query.Or:
 			or := elastic.NewBoolQuery()
-			for _, subExp := range t {
+			for _, subExp := range *t {
 				sq, err := translatePredicate(query.Predicate{subExp})
 				if err != nil {
 					return nil, err
@@ -78,28 +78,28 @@ func translatePredicate(q query.Predicate) ([]elastic.Query, error) {
 				or.Should(sq...)
 			}
 			qs = append(qs, or)
-		case query.In:
+		case *query.In:
 			qs = append(qs, elastic.NewTermsQuery(getField(t.Field, true), valuesToInterface(t.Values)...))
-		case query.NotIn:
+		case *query.NotIn:
 			b := elastic.NewBoolQuery()
 			b.MustNot(elastic.NewTermsQuery(getField(t.Field, true), valuesToInterface(t.Values)...))
 			qs = append(qs, b)
-		case query.Equal:
+		case *query.Equal:
 			qs = append(qs, elastic.NewTermQuery(getField(t.Field, true), t.Value))
-		case query.NotEqual:
+		case *query.NotEqual:
 			b := elastic.NewBoolQuery()
 			b.MustNot(elastic.NewTermQuery(getField(t.Field, true), t.Value))
 			qs = append(qs, b)
-		case query.GreaterThan:
+		case *query.GreaterThan:
 			r := elastic.NewRangeQuery(getField(t.Field, false)).Gt(t.Value)
 			qs = append(qs, r)
-		case query.GreaterOrEqual:
+		case *query.GreaterOrEqual:
 			r := elastic.NewRangeQuery(getField(t.Field, false)).Gte(t.Value)
 			qs = append(qs, r)
-		case query.LowerThan:
+		case *query.LowerThan:
 			r := elastic.NewRangeQuery(getField(t.Field, false)).Lt(t.Value)
 			qs = append(qs, r)
-		case query.LowerOrEqual:
+		case *query.LowerOrEqual:
 			r := elastic.NewRangeQuery(getField(t.Field, false)).Lte(t.Value)
 			qs = append(qs, r)
 		default:

--- a/query_test.go
+++ b/query_test.go
@@ -17,7 +17,7 @@ func (u UnsupportedExpression) Match(p map[string]interface{}) bool {
 	return false
 }
 
-func (u UnsupportedExpression) Validate(v schema.Validator) error {
+func (u UnsupportedExpression) Prepare(v schema.Validator) error {
 	return nil
 }
 
@@ -78,9 +78,9 @@ func TestTranslatePredicateInvalid(t *testing.T) {
 	var err error
 	_, err = translatePredicate(query.Predicate{UnsupportedExpression{}})
 	assert.Equal(t, resource.ErrNotImplemented, err)
-	_, err = translatePredicate(query.Predicate{query.And{UnsupportedExpression{}}})
+	_, err = translatePredicate(query.Predicate{&query.And{UnsupportedExpression{}}})
 	assert.Equal(t, resource.ErrNotImplemented, err)
-	_, err = translatePredicate(query.Predicate{query.Or{UnsupportedExpression{}}})
+	_, err = translatePredicate(query.Predicate{&query.Or{UnsupportedExpression{}}})
 	assert.Equal(t, resource.ErrNotImplemented, err)
 }
 


### PR DESCRIPTION
…eters by pointer.